### PR TITLE
.DS_Storeをgitignoreに追記

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 log.txt*
+.DS_Store


### PR DESCRIPTION
仮想マシンでアプリケーションを実行した際に表示される.DS_Storeをバージョン管理の対象から外すため、gitignoreに.DS_Storeを追加しました。